### PR TITLE
consistent with other NCEPLIBS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+build/
+install/
+
+*.[ao]
+*.mod
+*.so
+.DS_Store
+
+*.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 file(STRINGS "VERSION" pVersion)
 
 project(
-    bufr 
+    bufr
     VERSION ${pVersion}
     LANGUAGES C Fortran)
 

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,20 +1,19 @@
 @PACKAGE_INIT@
 
-#  * @PROJECT_NAME@::@PROJECT_NAME@_4 - real32 library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_8 - real64 library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_d - mixed library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_DA_4 - real32 library target with dynamic allocation
-#  * @PROJECT_NAME@::@PROJECT_NAME@_DA_8 - real64 library target with dynamic allocation
-#  * @PROJECT_NAME@::@PROJECT_NAME@_DA_d - mixed library target with dynamic allocation
-
+#  * @PROJECT_NAME@::@PROJECT_NAME@_4_DA - real32 library target with dynamic allocation
+#  * @PROJECT_NAME@::@PROJECT_NAME@_8_DA - real64 library target with dynamic allocation
+#  * @PROJECT_NAME@::@PROJECT_NAME@_d_DA - mixed library target with dynamic allocation
+#  * @PROJECT_NAME@::@PROJECT_NAME@_4    - real32 library target
+#  * @PROJECT_NAME@::@PROJECT_NAME@_8    - real64 library target
+#  * @PROJECT_NAME@::@PROJECT_NAME@_d    - mixed library target
 
 # Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
-# Get the build type from real32 library target
-get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4 IMPORTED_CONFIGURATIONS)
+# Get the build type from real32 library target with dyanmic allocation
+get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4_DA IMPORTED_CONFIGURATIONS)
 
 check_required_components("@PROJECT_NAME@")
 
-get_target_property(location @PROJECT_NAME@::@PROJECT_NAME@_4 LOCATION)
+get_target_property(location @PROJECT_NAME@::@PROJECT_NAME@_4_DA LOCATION)
 message(STATUS "Found @PROJECT_NAME@: ${location} (found version \"@PROJECT_VERSION@\")")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
   set(c_8_defs "F77_INTSIZE_8")
   set(c_8_DA_defs ${c_8_defs})
 
-  set(CMAKE_Fortran_FLAGS "-g -traceback -axCORE-AVX2")
+  set(CMAKE_Fortran_FLAGS "-g -traceback")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 
@@ -16,7 +16,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 
   set(CMAKE_C_FLAGS_DEBUG "-ggdb -Wall -O0")
 
-  set(CMAKE_Fortran_FLAGS "-g -fbacktrace -funroll-loops -mavx2")
+  set(CMAKE_Fortran_FLAGS "-g -fbacktrace")
   set(CMAKE_Fortran_FLAGS_DEBUG "-ggdb -Wall -O0")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 
@@ -25,7 +25,25 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 
 endif()
 
-add_compile_definitions(UNDERSCORE)
+# Extract BUFRLIB parameters
+file(READ bufrlib.prm _bufrlib_prm_str)
+foreach(_var IN ITEMS MAXNC MXNAF)
+    if(_bufrlib_prm_str MATCHES "${_var} = ([0-9]+)")
+      list(APPEND c_defs ${_var}=${CMAKE_MATCH_1})
+    else()
+      message(FATAL_ERROR "Unable to parse variable ${_var} value from file: src/bufrlib.prm")
+    endif()
+endforeach()
+
+list(APPEND underscore_def UNDERSCORE)
+
+include(TestBigEndian)
+test_big_endian(IS_BIG_ENDIAN)
+if(IS_BIG_ENDIAN)
+  list(APPEND endian_def BIG_ENDIAN)
+else()
+  list(APPEND endian_def LITTLE_ENDIAN)
+endif()
 
 include("list_of_files.cmake")
 
@@ -51,12 +69,17 @@ foreach(kind ${kinds})
   add_library(${lib_name}_f STATIC OBJECT ${fortran_src})
   set_target_properties(${lib_name}_f PROPERTIES COMPILE_FLAGS
                                                  "${fortran_${kind}_flags}")
-  target_compile_definitions(${lib_name}_f PRIVATE "${allocation_def}")
+  target_compile_definitions(${lib_name}_f PUBLIC "${allocation_def}")
+  target_compile_definitions(${lib_name}_f PUBLIC "${underscore_def}")
+  target_compile_definitions(${lib_name}_f PRIVATE "${endian_def}")
 
   add_library(${lib_name}_c STATIC OBJECT ${c_src})
   set_target_properties(${lib_name}_c PROPERTIES COMPILE_FLAGS
                                                  "${c_${kind}_flags}")
-  target_compile_definitions(${lib_name}_c PRIVATE "${allocation_def}")
+  target_compile_definitions(${lib_name}_c PUBLIC "${allocation_def}")
+  target_compile_definitions(${lib_name}_c PUBLIC "${underscore_def}")
+  target_compile_definitions(${lib_name}_c PRIVATE "${endian_def}")
+  target_compile_definitions(${lib_name}_c PRIVATE "${c_defs}")
   target_compile_definitions(${lib_name}_c PRIVATE "${c_${kind}_defs}")
 
   set_target_properties(${lib_name}_f PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
@@ -69,8 +92,12 @@ foreach(kind ${kinds})
     $<BUILD_INTERFACE:${module_dir}>
     $<INSTALL_INTERFACE:include_${kind}>)
 
+  target_compile_definitions(${lib_name} PUBLIC "${underscore_def}")
+  target_compile_definitions(${lib_name} PUBLIC "${allocation_def}")
+
   list(APPEND LIB_TARGETS ${lib_name})
   install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
+  install(FILES ${c_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind})
 endforeach()
 
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,69 +1,68 @@
-
 if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
-  set(definitions "UNDERSCORE")
-  set (FREAL8 "-r8")
-  set (FINT8 "-i8")
-  set (TRACEBACK "-traceback")
-  set (MMMED "-mcmodel=medium")
-  set (AVX2 "-axCORE-AVX2")
-  set(c_DA_allocation_def "DYNAMIC_ALLOCATION")
-  set(c_nonDA_allocation_def "STATIC_ALLOCATION")
+
+  set(c_8_defs "F77_INTSIZE_8")
+  set(c_8_DA_defs ${c_8_defs})
+
+  set(CMAKE_Fortran_FLAGS "-g -traceback -axCORE-AVX2")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+
+  set(fortran_8_flags "-r8 -i8")
+  set(fortran_d_flags "-r8")
+  set(fortran_8_DA_flags ${fortran_8_flags})
+  set(fortran_d_DA_flags ${fortran_d_flags})
+
 elseif(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
-  set(definitions "UNDERSCORE" "DYNAMIC_ALLOCATION")
-  set (FREAL8 "-fdefault-double-8" "-fdefault-real-8")
-  set (FINT8 "-fdefault-integer-8")
-  set (TRACEBACK "-fbacktrace")
-  set (MMMED "")
-  set (AVX2 "-mavx2")
+
+  set(CMAKE_C_FLAGS_DEBUG "-ggdb -Wall -O0")
+
+  set(CMAKE_Fortran_FLAGS "-g -fbacktrace -funroll-loops -mavx2")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-ggdb -Wall -O0")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+
+  set(fortran_8_flags "-fdefault-real-8 -fdefault-integer-8")
+  set(fortran_d_flags "-fdefault-real-8")
+
 endif()
-set (FOPT3 "-O3")
-set (DEBINFO "-g")
-add_compile_definitions(${definitions})
 
-
-set(fortran_8_flags ${FREAL8} ${FINT8} ${TRACEBACK})
-set(shared_flags  ${DEBINFO} ${FOPT3} ${AVX2})
-set(fortran_8_DA_flags ${FREAL8} ${FINT8} ${TRACEBACK})
-set(fortran_d_DA_flags ${FREAL8} ${TRACEBACK})
-set(c_8_DA_definitions "F77_INTSIZE_8")
-set(c_8_definitions "F77_INTSIZE_8")
+add_compile_definitions(UNDERSCORE)
 
 include("list_of_files.cmake")
-set(kinds "4" "d" "8" "4_DA" "8_DA" "d_DA")
+
+# Both GNU and Intel support DYNAMIC_ALLOCATION
+list(APPEND kinds "4_DA" "8_DA" "d_DA")
+
+# Only Intel supports STATIC_ALLOCATION
+if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
+  list(APPEND kinds "4" "8" "d")
+endif()
 
 foreach(kind ${kinds})
   set(lib_name ${PROJECT_NAME}_${kind})
+  set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include_${kind}")
 
-  # different compiler definitions for Intel in DA vs non-DA
-  # -DDYNAMIC_ALLOCATION when compiled with DA and -DSTATIC_ALLOCATION
-  # check current kind and if it has 'DA' in it then set compiler def
-
-  if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
-    string(FIND ${kind} "DA" isDA)
-    if(isDA GREATER_EQUAL 0)
-      set(allocation_def ${c_DA_allocation_def})
-    else()
-      set(allocation_def ${c_nonDA_allocation_def})
-    endif()
+  # determine ALLOCATION based on kind
+  if(${kind} MATCHES "^([4|8|d]_DA)$")
+    set(allocation_def "DYNAMIC_ALLOCATION")
+  else()
+    set(allocation_def "STATIC_ALLOCATION")
   endif()
 
   add_library(${lib_name}_f STATIC OBJECT ${fortran_src})
-  set_target_properties(${lib_name}_f PROPERTIES
-    COMPILE_OPTIONS "${shared_flags};${shared_fortran_flags};${fortran_${kind}_flags}")
-  set_target_properties(${lib_name}_f PROPERTIES
-    COMPILE_DEFINITIONS "${allocation_def}")
+  set_target_properties(${lib_name}_f PROPERTIES COMPILE_FLAGS
+                                                 "${fortran_${kind}_flags}")
+  target_compile_definitions(${lib_name}_f PRIVATE "${allocation_def}")
 
   add_library(${lib_name}_c STATIC OBJECT ${c_src})
-  set_target_properties(${lib_name}_c PROPERTIES
-    COMPILE_OPTIONS "${shared_flags};${c_${kind}_flags}")
+  set_target_properties(${lib_name}_c PROPERTIES COMPILE_FLAGS
+                                                 "${c_${kind}_flags}")
+  target_compile_definitions(${lib_name}_c PRIVATE "${allocation_def}")
+  target_compile_definitions(${lib_name}_c PRIVATE "${c_${kind}_defs}")
 
-  set_target_properties(${lib_name}_c PROPERTIES
-    COMPILE_DEFINITIONS "${c_${kind}_definitions};${allocation_def}")
-
-  set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include_${kind}")
   set_target_properties(${lib_name}_f PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
 
-  add_library(${lib_name} STATIC $<TARGET_OBJECTS:${lib_name}_f> $<TARGET_OBJECTS:${lib_name}_c>)
+  add_library(${lib_name} STATIC $<TARGET_OBJECTS:${lib_name}_f>
+                                 $<TARGET_OBJECTS:${lib_name}_c>)
   add_library(${PROJECT_NAME}::${lib_name} ALIAS ${lib_name})
 
   target_include_directories(${lib_name} INTERFACE
@@ -72,7 +71,6 @@ foreach(kind ${kinds})
 
   list(APPEND LIB_TARGETS ${lib_name})
   install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
-
 endforeach()
 
 install(

--- a/src/list_of_files.cmake
+++ b/src/list_of_files.cmake
@@ -1,4 +1,4 @@
-set(fortran_src 
+set(fortran_src
   adn30.f
   atrcpt.f
   bfrini.f
@@ -304,7 +304,7 @@ set(fortran_src
   openbf.F
   pkvs01.F
   wrdlen.F )
-set(c_src 
+set(c_src
   arallocc.c
   ardllocc.c
   bort_exit.c

--- a/src/list_of_files.cmake
+++ b/src/list_of_files.cmake
@@ -1,4 +1,64 @@
 set(fortran_src
+  modv_MAXCD.F
+  modv_MAXJL.F
+  modv_MAXMEM.F
+  modv_MAXMSG.F
+  modv_MAXSS.F
+  modv_MAXTBA.F
+  modv_MAXTBB.F
+  modv_MAXTBD.F
+  modv_MXBTM.F
+  modv_MXBTMSE.F
+  modv_MXCDV.F
+  modv_MXCSB.F
+  modv_MXDXTS.F
+  modv_MXH4WLC.F
+  modv_MXLCC.F
+  modv_MXMSGL.F
+  modv_MXMTBB.F
+  modv_MXMTBD.F
+  modv_MXMTBF.F
+  modv_MXNRV.F
+  modv_MXRST.F
+  modv_MXS01V.F
+  modv_MXTAMC.F
+  modv_MXTCO.F
+  modv_NFILES.F
+  moda_bitbuf.F
+  moda_bitmaps.F
+  moda_bufrmg.F
+  moda_bufrsr.F
+  moda_comprs.F
+  moda_comprx.F
+  moda_h4wlc.F
+  moda_idrdm.F
+  moda_ifopbf.F
+  moda_ival.F
+  moda_ivttmp.F
+  moda_lushr.F
+  moda_mgwa.F
+  moda_mgwb.F
+  moda_msgcwd.F
+  moda_msglim.F
+  moda_msgmem.F
+  moda_mstabs.F
+  moda_nmikrp.F
+  moda_nrv203.F
+  moda_nulbfr.F
+  moda_rdmtb.F
+  moda_rlccmn.F
+  moda_s01cm.F
+  moda_sc3bfr.F
+  moda_stbfr.F
+  moda_stcode.F
+  moda_tababd.F
+  moda_tables.F
+  moda_ufbcpl.F
+  moda_unptyp.F
+  moda_usrbit.F
+  moda_usrint.F
+  moda_usrtmp.F
+  moda_xtab.F
   adn30.f
   atrcpt.f
   bfrini.f
@@ -241,69 +301,10 @@ set(fortran_src
   ireadmt.F
   irev.F
   isetprm.F
-  moda_bitbuf.F
-  moda_bitmaps.F
-  moda_bufrmg.F
-  moda_bufrsr.F
-  moda_comprs.F
-  moda_comprx.F
-  moda_h4wlc.F
-  moda_idrdm.F
-  moda_ifopbf.F
-  moda_ival.F
-  moda_ivttmp.F
-  moda_lushr.F
-  moda_mgwa.F
-  moda_mgwb.F
-  moda_msgcwd.F
-  moda_msglim.F
-  moda_msgmem.F
-  moda_mstabs.F
-  moda_nmikrp.F
-  moda_nrv203.F
-  moda_nulbfr.F
-  moda_rdmtb.F
-  moda_rlccmn.F
-  moda_s01cm.F
-  moda_sc3bfr.F
-  moda_stbfr.F
-  moda_stcode.F
-  moda_tababd.F
-  moda_tables.F
-  moda_ufbcpl.F
-  moda_unptyp.F
-  moda_usrbit.F
-  moda_usrint.F
-  moda_usrtmp.F
-  moda_xtab.F
-  modv_MAXCD.F
-  modv_MAXJL.F
-  modv_MAXMEM.F
-  modv_MAXMSG.F
-  modv_MAXSS.F
-  modv_MAXTBA.F
-  modv_MAXTBB.F
-  modv_MAXTBD.F
-  modv_MXBTM.F
-  modv_MXBTMSE.F
-  modv_MXCDV.F
-  modv_MXCSB.F
-  modv_MXDXTS.F
-  modv_MXH4WLC.F
-  modv_MXLCC.F
-  modv_MXMSGL.F
-  modv_MXMTBB.F
-  modv_MXMTBD.F
-  modv_MXMTBF.F
-  modv_MXNRV.F
-  modv_MXRST.F
-  modv_MXS01V.F
-  modv_MXTAMC.F
-  modv_MXTCO.F
-  modv_NFILES.F
   openbf.F
   pkvs01.F
-  wrdlen.F )
+  wrdlen.F)
+
 set(c_src
   arallocc.c
   ardllocc.c
@@ -327,4 +328,11 @@ set(c_src
   srchtbf.c
   strtbfe.c
   stseq.c
-  wrdesc.c )
+  wrdesc.c)
+
+set(c_hdr
+  bufrlib.h
+  cfe.h
+  cobfl.h
+  cread.h
+  mstabs.h)


### PR DESCRIPTION
make consistent with other nceplibs. DA is supported in Intel and GNU.
Disable SA for GNU builds.

order of Fortran source code matters, even in CMake!
Checks for endian and adds appropriate compile definition
Adds public and private definitions
Adds missing C compile time definitions from bufrlib.prm
Installs c headers



Change-Id: I510748fa6dae6288f660b912a88bf037f75511ed